### PR TITLE
Implement OCR-based manga recap pipeline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ O **MangaRecap** é uma ferramenta que gera vídeos curtos e roteiros para **res
 * 🎬 **Geração de vídeo curto**: automatiza a criação de vídeos estilo “shorts” contendo síntese da história.
 * 📝 **Roteiros prontos**: produz scripts editáveis para narradores baseados nos pontos principais.
 * 🔍 **Sumarização automática**: extrai os principais eventos, personagens e diálogos.
+* 🖼️ **Processamento de imagens**: recebe imagens de cada capítulo, utiliza OCR para extrair os textos e gerar o resumo.
 * 🛠️ **Exportação versátil**: permite exportar vídeo+roteiro em MP4, TXT ou JSON.
 
 ---
@@ -49,12 +50,12 @@ pip install -r requirements.txt
 ### 4. Execute o script principal
 
 ```bash
-python main.py --input arquivo_manga.txt --output resumo.mp4
+python main.py --chapters_dir caminho/para/capitulos --output resumo.mp4
 ```
 
 Parâmetros disponíveis:
 
-* `--input`: arquivo de texto com resumo bruto do mangá
+* `--chapters_dir`: pasta contendo subdiretórios com as imagens de cada capítulo
 * `--output`: nome do arquivo de vídeo de saída
 * `--lang`: idioma da narração (ex: `pt`, `en`)
 
@@ -79,10 +80,10 @@ Parâmetros disponíveis:
 ## Exemplos de uso
 
 ```bash
-python main.py --input one_piece_summary.txt --output one_piece_short.mp4 --lang pt
+python main.py --chapters_dir manga/one_piece/chapters --output one_piece_short.mp4 --lang pt
 ```
 
-Gera um vídeo com resumo narrado de *One Piece*.
+Gera um vídeo com resumo narrado de *One Piece* a partir das imagens dos capítulos.
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -1,0 +1,51 @@
+import argparse
+import os
+from modules.ocr import extract_text_from_chapter
+from modules.summarizer import summarize_text
+from modules.script_gen import build_script
+from modules.audio_gen import text_to_speech
+from modules.video_gen import create_video
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate video recap from manga chapters")
+    parser.add_argument("--chapters_dir", required=True, help="Directory containing chapter folders with images")
+    parser.add_argument("--output", required=True, help="Output video file")
+    parser.add_argument("--lang", default="pt", help="Language for narration")
+    parser.add_argument("--temp", default="temp", help="Temporary working directory")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    os.makedirs(args.temp, exist_ok=True)
+
+    # Discover chapter directories
+    chapter_dirs = [os.path.join(args.chapters_dir, d)
+                    for d in sorted(os.listdir(args.chapters_dir))
+                    if os.path.isdir(os.path.join(args.chapters_dir, d))]
+    if not chapter_dirs:
+        raise ValueError("No chapter directories found")
+
+    # OCR text extraction
+    chapter_texts = [extract_text_from_chapter(chapter) for chapter in chapter_dirs]
+
+    # Summarization
+    summaries = summarize_text(chapter_texts)
+
+    # Build script
+    script = build_script(summaries)
+    script_path = os.path.join(args.temp, "script.txt")
+    with open(script_path, "w") as f:
+        f.write(script)
+
+    # Generate audio narration
+    audio_path = os.path.join(args.temp, "narration.mp3")
+    text_to_speech(script, audio_path, lang=args.lang)
+
+    # Generate video from images and narration
+    create_video(chapter_dirs, audio_path, args.output)
+
+
+if __name__ == "__main__":
+    main()

--- a/modules/audio_gen.py
+++ b/modules/audio_gen.py
@@ -1,0 +1,14 @@
+from typing import Optional
+import pyttsx3
+
+
+def text_to_speech(script: str, output_path: str, lang: str = "pt") -> None:
+    """Generate speech audio from text using pyttsx3."""
+    engine = pyttsx3.init()
+    # Attempt to set language voice
+    for voice in engine.getProperty('voices'):
+        if lang in voice.languages[0].decode('utf-8'):
+            engine.setProperty('voice', voice.id)
+            break
+    engine.save_to_file(script, output_path)
+    engine.runAndWait()

--- a/modules/ocr.py
+++ b/modules/ocr.py
@@ -1,0 +1,18 @@
+import os
+from typing import List
+from PIL import Image
+import pytesseract
+
+def extract_text_from_chapter(chapter_dir: str) -> str:
+    """Extract concatenated text from all images in a chapter directory."""
+    texts: List[str] = []
+    for file in sorted(os.listdir(chapter_dir)):
+        if file.lower().endswith((".png", ".jpg", ".jpeg", ".webp")):
+            path = os.path.join(chapter_dir, file)
+            try:
+                img = Image.open(path)
+                text = pytesseract.image_to_string(img)
+                texts.append(text)
+            except Exception as exc:
+                print(f"Failed to process {path}: {exc}")
+    return "\n".join(texts)

--- a/modules/script_gen.py
+++ b/modules/script_gen.py
@@ -1,0 +1,9 @@
+from typing import List
+
+
+def build_script(chapter_summaries: List[str]) -> str:
+    """Combine chapter summaries into a single narration script."""
+    script_lines = []
+    for i, summary in enumerate(chapter_summaries, 1):
+        script_lines.append(f"Capítulo {i} resumo:\n{summary}\n")
+    return "\n".join(script_lines)

--- a/modules/summarizer.py
+++ b/modules/summarizer.py
@@ -1,0 +1,19 @@
+from typing import List
+from transformers import pipeline
+
+
+def summarize_text(chapter_texts: List[str], model: str = "facebook/bart-large-cnn") -> List[str]:
+    """Summarize a list of chapter texts."""
+    summarizer = pipeline("summarization", model=model)
+    summaries: List[str] = []
+    for text in chapter_texts:
+        if not text.strip():
+            summaries.append("")
+            continue
+        try:
+            summary = summarizer(text, max_length=130, min_length=30, do_sample=False)
+            summaries.append(summary[0]['summary_text'])
+        except Exception as exc:
+            print(f"Failed to summarize text: {exc}")
+            summaries.append("")
+    return summaries

--- a/modules/video_gen.py
+++ b/modules/video_gen.py
@@ -1,0 +1,20 @@
+import os
+from typing import List
+from moviepy.editor import ImageClip, AudioFileClip, concatenate_videoclips
+
+
+def create_video(chapter_dirs: List[str], audio_path: str, output_path: str) -> None:
+    """Create a simple video using images from chapters and an audio narration."""
+    clips = []
+    for chapter in chapter_dirs:
+        for file in sorted(os.listdir(chapter)):
+            if file.lower().endswith((".png", ".jpg", ".jpeg", ".webp")):
+                img_path = os.path.join(chapter, file)
+                clip = ImageClip(img_path).set_duration(2)
+                clips.append(clip)
+    if not clips:
+        raise ValueError("No images found for video generation")
+    video = concatenate_videoclips(clips, method="compose")
+    audio = AudioFileClip(audio_path)
+    video = video.set_audio(audio)
+    video.write_videofile(output_path, fps=24)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,5 @@
+pytesseract
+Pillow
+transformers
+moviepy
+pyttsx3


### PR DESCRIPTION
## Summary
- implement core modules: OCR, summarizer, script generation, audio and video generation
- add main entrypoint that processes chapter folders and outputs a narrated video
- document new workflow and usage in README
- track dependencies and ignore build artefacts

## Testing
- `python -m py_compile main.py modules/*.py`

------
https://chatgpt.com/codex/tasks/task_e_6858ccc4dd0883208fc97911f863046c