### PR TITLE
Add configuration module and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,10 @@ Parâmetros disponíveis:
 * `--output`: nome do arquivo de vídeo de saída
 * `--lang`: idioma da narração (ex: `pt`, `en`)
 
+As configurações padrão desses argumentos estão em `modules/config.py`. Você
+pode editar esse arquivo para alterar valores como modelo de IA, idioma ou
+prompt de sumarização sem precisar passar tudo pela linha de comando.
+
 ---
 
 ## Estrutura do projeto
@@ -70,10 +74,21 @@ Parâmetros disponíveis:
 │   ├── summarizer.py   # Sumarização de texto
 │   ├── script_gen.py   # Geração de roteiro
 │   ├── video_gen.py    # Montagem de vídeo
-│   └── audio_gen.py    # Geração de áudio narrado
+│   ├── audio_gen.py    # Geração de áudio narrado
+│   └── config.py       # Valores padrão de configuração
 ├── requirements.txt
-├── README.md
+└── README.md
 ```
+
+## Fluxo de execução
+
+1. `main.py` lê as configurações de `modules/config.py` e os argumentos da linha de comando.
+2. As imagens são processadas por `modules/ocr.py` para extrair o texto de cada capítulo.
+3. O texto extraído é resumido em `modules/summarizer.py` utilizando o prompt padrão.
+4. `modules/script_gen.py` combina os resumos em um roteiro único.
+5. Esse roteiro é transformado em narração em `modules/audio_gen.py`.
+6. Por fim `modules/video_gen.py` sincroniza as imagens com o áudio e gera o vídeo final.
+
 
 ---
 

--- a/main.py
+++ b/main.py
@@ -5,19 +5,28 @@ from modules.summarizer import summarize_text
 from modules.script_gen import build_script
 from modules.audio_gen import text_to_speech
 from modules.video_gen import create_video
+from modules.config import (
+    DEFAULT_TEMP_DIR,
+    DEFAULT_MODEL,
+    DEFAULT_PROMPT,
+    DEFAULT_LANG,
+    DEFAULT_VOICE,
+    DEFAULT_IMAGE_DURATION,
+    DEFAULT_USE_TTS,
+)
 
 
 def parse_args():
     parser = argparse.ArgumentParser(description="Generate video recap from manga chapters")
     parser.add_argument("--chapters_dir", required=True, help="Directory containing chapter folders with images")
     parser.add_argument("--output", required=True, help="Output video file")
-    parser.add_argument("--lang", default="pt", help="Language for narration")
-    parser.add_argument("--temp", default="temp", help="Temporary working directory")
-    parser.add_argument("--model", default="google/flan-t5-base", help="HuggingFace model for summarization")
-    parser.add_argument("--prompt", help="Custom prompt for summarization")
-    parser.add_argument("--voice", help="Voice name for narration")
-    parser.add_argument("--image_duration", type=float, help="Duration for each image in seconds")
-    parser.add_argument("--use_tts", action="store_true", help="Use neural TTS if available")
+    parser.add_argument("--lang", default=DEFAULT_LANG, help="Language for narration")
+    parser.add_argument("--temp", default=DEFAULT_TEMP_DIR, help="Temporary working directory")
+    parser.add_argument("--model", default=DEFAULT_MODEL, help="HuggingFace model for summarization")
+    parser.add_argument("--prompt", default=DEFAULT_PROMPT, help="Custom prompt for summarization")
+    parser.add_argument("--voice", default=DEFAULT_VOICE, help="Voice name for narration")
+    parser.add_argument("--image_duration", type=float, default=DEFAULT_IMAGE_DURATION, help="Duration for each image in seconds")
+    parser.add_argument("--use_tts", action="store_true", default=DEFAULT_USE_TTS, help="Use neural TTS if available")
     return parser.parse_args()
 
 

--- a/modules/config.py
+++ b/modules/config.py
@@ -1,0 +1,12 @@
+"""Configuration settings for MangaRecap."""
+
+DEFAULT_TEMP_DIR = "temp"
+DEFAULT_MODEL = "google/flan-t5-base"
+DEFAULT_PROMPT = (
+    "Resuma o seguinte texto de forma narrativa. Utilize '[PAUSA]' para"
+    " indicar pausas e sugira imagens no formato [IMAGEM: descricao]."
+)
+DEFAULT_LANG = "pt"
+DEFAULT_VOICE = None
+DEFAULT_IMAGE_DURATION = None
+DEFAULT_USE_TTS = False

--- a/modules/summarizer.py
+++ b/modules/summarizer.py
@@ -1,20 +1,18 @@
 from typing import List
 from transformers import pipeline
+from .config import DEFAULT_MODEL, DEFAULT_PROMPT
 
 
 def summarize_text(
     chapter_texts: List[str],
-    model: str = "google/flan-t5-base",
+    model: str = DEFAULT_MODEL,
     prompt: str | None = None,
     max_new_tokens: int = 256,
 ) -> List[str]:
     """Summarize a list of chapter texts using a customizable prompt."""
 
     if prompt is None:
-        prompt = (
-            "Resuma o seguinte texto de forma narrativa. Utilize '[PAUSA]' para "
-            "indicar pausas e sugira imagens no formato [IMAGEM: descricao]."
-        )
+        prompt = DEFAULT_PROMPT
 
     summarizer = pipeline("text2text-generation", model=model)
 


### PR DESCRIPTION
## Summary
- centralize default config options in `modules/config.py`
- use config defaults in summarizer and argument parsing
- document configuration and execution flow in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6858dad58cd08320a2a0d3053feb4e89