### PR TITLE
Add OpenAI Vision OCR provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,8 @@ OPENAI_API_KEY=sk-sua-chave-aqui
 OPENAI_MODEL=gpt-4o-mini
 OPENAI_TTS_MODEL=tts-1
 OPENAI_TTS_VOICE=alloy
+OPENAI_VISION_MODEL=gpt-4o
+MMR_LANG=pt
 ```
 
 ### Configurações Disponíveis
@@ -88,6 +90,8 @@ OPENAI_TTS_VOICE=alloy
 | `OPENAI_MODEL` | Modelo GPT | `gpt-4o-mini` |
 | `OPENAI_TTS_MODEL` | Modelo TTS | `tts-1` |
 | `OPENAI_TTS_VOICE` | Voz do TTS | `alloy` |
+| `OPENAI_VISION_MODEL` | Modelo de OCR Vision | `gpt-4o` |
+| `MMR_LANG` | Idioma padrão das saídas | `pt` |
 
 ### Vozes Disponíveis
 - **alloy**: Voz neutra e clara
@@ -104,8 +108,11 @@ O módulo de OCR agora suporta múltiplos provedores com fallback automático.
 
 | Provider | Descrição |
 |----------|-----------|
+| **OpenAI Vision** | Usa GPT-4o para OCR e contexto (requer API key) |
 | **TrOCR** | Usa modelo da HuggingFace para maior precisão (requer `torch`) |
 | **Tesseract** | Padrão e sempre disponível |
+
+A integração OpenAI Vision permite extrair texto, personagens e contexto de cada página.
 
 ### 1. **OpenAI Provider** (Premium)
 ```bash

--- a/env.example
+++ b/env.example
@@ -5,6 +5,8 @@ OPENAI_API_KEY=sk-your-openai-api-key-here
 OPENAI_MODEL=gpt-4o-mini
 OPENAI_TTS_MODEL=tts-1
 OPENAI_TTS_VOICE=alloy
+OPENAI_VISION_MODEL=gpt-4o
+MMR_LANG=pt
 
 # Available voices: alloy, echo, fable, onyx, nova, shimmer
 # Available models: gpt-4o-mini, gpt-4o, gpt-4-turbo, gpt-3.5-turbo

--- a/modules/__init__.py
+++ b/modules/__init__.py
@@ -27,7 +27,12 @@ except ImportError:  # pragma: no cover - optional dependency
     generate_scripts_from_ocr = None
 
 from .ocr import extract_text_from_chapter
-from .ocr_provider import OCRManager, TesseractProvider, TrOCRProvider
+from .ocr_provider import (
+    OCRManager,
+    TesseractProvider,
+    TrOCRProvider,
+    OpenAIVisionProvider,
+)
 from .audio_gen import text_to_speech
 from .video_gen import create_video
 
@@ -43,4 +48,5 @@ __all__ = [
     "OCRManager",
     "TesseractProvider",
     "TrOCRProvider",
+    "OpenAIVisionProvider",
 ]

--- a/modules/config.py
+++ b/modules/config.py
@@ -14,7 +14,7 @@ except ImportError:
 DEFAULT_TEMP_DIR = "temp"
 
 # Language and video settings
-DEFAULT_LANG = "pt"
+DEFAULT_LANG = os.getenv("MMR_LANG", "pt")
 DEFAULT_IMAGE_DURATION = None  # Auto-calculated based on audio
 DEFAULT_VIDEO_WIDTH = 1280
 DEFAULT_VIDEO_HEIGHT = 720
@@ -24,6 +24,7 @@ OPENAI_API_KEY = os.getenv("OPENAI_API_KEY")
 OPENAI_MODEL = os.getenv("OPENAI_MODEL", "gpt-4o-mini")
 OPENAI_TTS_MODEL = os.getenv("OPENAI_TTS_MODEL", "tts-1")
 OPENAI_TTS_VOICE = os.getenv("OPENAI_TTS_VOICE", "alloy")
+OPENAI_VISION_MODEL = os.getenv("OPENAI_VISION_MODEL", "gpt-4o")
 
 # Configuration validation and info
 def get_openai_config():
@@ -32,7 +33,8 @@ def get_openai_config():
         "api_key": OPENAI_API_KEY,
         "model": OPENAI_MODEL,
         "tts_model": OPENAI_TTS_MODEL,
-        "tts_voice": OPENAI_TTS_VOICE
+        "tts_voice": OPENAI_TTS_VOICE,
+        "vision_model": OPENAI_VISION_MODEL,
     }
 
 def is_openai_configured():
@@ -46,5 +48,6 @@ def print_config_status():
     print(f"  OPENAI_MODEL: {OPENAI_MODEL}")
     print(f"  OPENAI_TTS_MODEL: {OPENAI_TTS_MODEL}")
     print(f"  OPENAI_TTS_VOICE: {OPENAI_TTS_VOICE}")
+    print(f"  OPENAI_VISION_MODEL: {OPENAI_VISION_MODEL}")
     if not is_openai_configured():
         print("💡 Dica: Copie env.example para .env e configure sua API key")

--- a/modules/ocr_provider.py
+++ b/modules/ocr_provider.py
@@ -3,8 +3,13 @@
 from abc import ABC, abstractmethod
 from typing import Optional, List
 
+import base64
+import io
+
 from PIL import Image
 import pytesseract
+
+from .config import OPENAI_API_KEY, OPENAI_VISION_MODEL, DEFAULT_LANG
 
 
 class OCRProvider(ABC):
@@ -57,11 +62,70 @@ class TrOCRProvider(OCRProvider):
         return text.strip()
 
 
+class OpenAIVisionProvider(OCRProvider):
+    """OCR provider using OpenAI vision models with contextual extraction."""
+
+    def __init__(self, model: Optional[str] = None, lang: str = DEFAULT_LANG) -> None:
+        self.model = model or OPENAI_VISION_MODEL
+        self.lang = lang
+
+    def is_available(self) -> bool:
+        if not OPENAI_API_KEY:
+            return False
+        try:
+            import openai  # type: ignore
+        except Exception:
+            return False
+        return True
+
+    def extract_text(self, image: Image.Image) -> str:
+        if not self.is_available():
+            raise RuntimeError("OpenAI not configured")
+
+        import openai  # type: ignore
+
+        buffered = io.BytesIO()
+        image.save(buffered, format="PNG")
+        img_b64 = base64.b64encode(buffered.getvalue()).decode("utf-8")
+
+        prompt = (
+            "Read the text from this manga page and identify any characters and "
+            "context. Reply in {lang}."
+        ).format(lang=self.lang)
+
+        messages = [
+            {
+                "role": "user",
+                "content": [
+                    {"type": "text", "text": prompt},
+                    {"type": "image_url", "image_url": {"url": f"data:image/png;base64,{img_b64}"}},
+                ],
+            }
+        ]
+
+        response = openai.ChatCompletion.create(
+            model=self.model,
+            messages=messages,
+        )
+
+        return response.choices[0].message.get("content", "").strip()
+
+
 class OCRManager:
     """Manages multiple OCR providers with fallback."""
 
     def __init__(self, provider_name: Optional[str] = None) -> None:
         self.providers: List[OCRProvider] = []
+
+        if provider_name in (None, "openai"):
+            try:
+                openai_provider = OpenAIVisionProvider(lang=DEFAULT_LANG)
+                if openai_provider.is_available():
+                    self.providers.append(openai_provider)
+                else:
+                    print("⚠️  OpenAI Vision indisponível")
+            except Exception as exc:  # pragma: no cover - safety
+                print(f"⚠️  Erro ao iniciar OpenAI Vision: {exc}")
 
         if provider_name in (None, "trocr"):
             try:

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ requests
 beautifulsoup4
 selenium
 webdriver-manager
+openai


### PR DESCRIPTION
## Summary
- add optional OpenAI Vision OCR provider
- expose OPENAI_VISION_MODEL and default language via `MMR_LANG`
- document the new provider and settings
- include `openai` in requirements

## Testing
- `python test_openai.py --config` *(fails: ModuleNotFoundError: No module named 'PIL')*
- `pip install openai` *(fails: Tunnel connection failed: 403 Forbidden)*


------
https://chatgpt.com/codex/tasks/task_e_685cd00a46a083208a1e4fcab9dd96e3